### PR TITLE
MongoDB persistence adapter with Test Containers

### DIFF
--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
@@ -61,6 +65,22 @@
             <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- To use the "attached test JAR" from the "model" module -->
         <dependency>

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartLineItemMongoEntity.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartLineItemMongoEntity.java
@@ -1,0 +1,21 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * MongoDB document class for a shopping cart line item.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@Document(collection = "CartLineItem")
+@Getter
+@Setter
+public class CartLineItemMongoEntity {
+
+  @DBRef private ProductMongoEntity product;
+
+  private int quantity;
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartMapper.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartMapper.java
@@ -1,0 +1,52 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.model.cart.Cart;
+import eu.happycoders.shop.model.cart.CartLineItem;
+import eu.happycoders.shop.model.customer.CustomerId;
+
+/**
+ * Maps model carts and line items to MongoDB carts and line items - and vice versa.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+final class CartMapper {
+
+  private CartMapper() {}
+
+  static CartMongoEntity toMongoEntity(Cart cart) {
+    CartMongoEntity cartMongoEntity = new CartMongoEntity();
+    cartMongoEntity.setCustomerId(cart.id().value());
+
+    cartMongoEntity.setLineItems(
+        cart.lineItems().stream()
+            .map(lineItem -> toMongoEntity(cartMongoEntity, lineItem))
+            .toList());
+
+    return cartMongoEntity;
+  }
+
+  static CartLineItemMongoEntity toMongoEntity(
+      CartMongoEntity cartMongoEntity, CartLineItem lineItem) {
+    ProductMongoEntity productMongoEntity = new ProductMongoEntity();
+    productMongoEntity.setId(lineItem.product().id().value());
+
+    CartLineItemMongoEntity entity = new CartLineItemMongoEntity();
+    entity.setProduct(productMongoEntity);
+    entity.setQuantity(lineItem.quantity());
+
+    return entity;
+  }
+
+  static Cart toModelEntity(CartMongoEntity cartMongoEntity) {
+    CustomerId customerId = new CustomerId(cartMongoEntity.getCustomerId());
+    Cart cart = new Cart(customerId);
+
+    for (CartLineItemMongoEntity lineItemMongoEntity : cartMongoEntity.getLineItems()) {
+      cart.putProductIgnoringNotEnoughItemsInStock(
+          ProductMapper.toModelEntity(lineItemMongoEntity.getProduct()),
+          lineItemMongoEntity.getQuantity());
+    }
+
+    return cart;
+  }
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartMongoEntity.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/CartMongoEntity.java
@@ -1,0 +1,23 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+/**
+ * MongoDB document class for a shopping cart.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@Document(collection = "Cart")
+@Getter
+@Setter
+public class CartMongoEntity {
+
+  @Id private int customerId;
+
+  private List<CartLineItemMongoEntity> lineItems;
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoCartRepository.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoCartRepository.java
@@ -1,0 +1,46 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.application.port.out.persistence.CartRepository;
+import eu.happycoders.shop.model.cart.Cart;
+import eu.happycoders.shop.model.customer.CustomerId;
+import jakarta.transaction.Transactional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Persistence adapter: Stores carts via MongoDB in a database.
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@ConditionalOnProperty(name = "persistence", havingValue = "mongodb")
+@Repository
+public class MongoCartRepository implements CartRepository {
+
+  private final MongoCartSpringDataRepository mongoCartSpringDataRepository;
+
+  public MongoCartRepository(
+      MongoCartSpringDataRepository mongoCartSpringDataRepository) {
+    this.mongoCartSpringDataRepository = mongoCartSpringDataRepository;
+  }
+
+  @Override
+  @Transactional
+  public void save(Cart cart) {
+    mongoCartSpringDataRepository.save(CartMapper.toMongoEntity(cart));
+  }
+
+  @Override
+  @Transactional
+  public Optional<Cart> findByCustomerId(CustomerId customerId) {
+    Optional<CartMongoEntity> cartMongoEntity =
+        mongoCartSpringDataRepository.findById(customerId.value());
+    return cartMongoEntity.map(CartMapper::toModelEntity);
+  }
+
+  @Override
+  @Transactional
+  public void deleteByCustomerId(CustomerId customerId) {
+    mongoCartSpringDataRepository.deleteById(customerId.value());
+  }
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoCartSpringDataRepository.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoCartSpringDataRepository.java
@@ -1,0 +1,12 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data repository for {@link CartMongoEntity}.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@Repository
+public interface MongoCartSpringDataRepository extends MongoRepository<CartMongoEntity, Integer> {}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductRepository.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductRepository.java
@@ -1,0 +1,56 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.adapter.out.persistence.DemoProducts;
+import eu.happycoders.shop.application.port.out.persistence.ProductRepository;
+import eu.happycoders.shop.model.product.Product;
+import eu.happycoders.shop.model.product.ProductId;
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Persistence adapter: Stores products via MongoDB.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@ConditionalOnProperty(name = "persistence", havingValue = "mongodb")
+@Repository
+public class MongoProductRepository implements ProductRepository {
+
+  private final MongoProductSpringDataRepository springDataRepository;
+
+  public MongoProductRepository(MongoProductSpringDataRepository springDataRepository) {
+    this.springDataRepository = springDataRepository;
+  }
+
+  @PostConstruct
+  void createDemoProducts() {
+    DemoProducts.DEMO_PRODUCTS.forEach(this::save);
+  }
+
+  @Override
+  @Transactional
+  public void save(Product product) {
+    springDataRepository.save(ProductMapper.toMongoEntity(product));
+  }
+
+  @Override
+  @Transactional
+  public Optional<Product> findById(ProductId productId) {
+    Optional<ProductMongoEntity> mongoEntity = springDataRepository.findById(productId.value());
+    return mongoEntity.map(ProductMapper::toModelEntity);
+  }
+
+  @Override
+  @Transactional
+  public List<Product> findByNameOrDescription(String queryString) {
+    List<ProductMongoEntity> entities =
+        springDataRepository.findByNameOrDescriptionLike(queryString);
+
+    return ProductMapper.toModelEntities(entities);
+  }
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductSpringDataRepository.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductSpringDataRepository.java
@@ -1,0 +1,21 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Spring Data repository for {@link ProductMongoEntity}.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@Repository
+public interface MongoProductSpringDataRepository
+    extends MongoRepository<ProductMongoEntity, String> {
+
+  @Query("{ '$or': [ { 'name': { '$regex': ?0, '$options': 'i' } }, { 'description': { '$regex': ?0, '$options': 'i' } } ] }")
+  List<ProductMongoEntity> findByNameOrDescriptionLike(String pattern);
+
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/ProductMapper.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/ProductMapper.java
@@ -1,0 +1,45 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.model.money.Money;
+import eu.happycoders.shop.model.product.Product;
+import eu.happycoders.shop.model.product.ProductId;
+
+import java.util.Currency;
+import java.util.List;
+
+/**
+ * Maps a model product to a MongoDB product and vice versa.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+final class ProductMapper {
+
+  private ProductMapper() {}
+
+  static ProductMongoEntity toMongoEntity(Product product) {
+    ProductMongoEntity mongoEntity = new ProductMongoEntity();
+
+    mongoEntity.setId(product.id().value());
+    mongoEntity.setName(product.name());
+    mongoEntity.setDescription(product.description());
+    mongoEntity.setPriceCurrency(product.price().currency().getCurrencyCode());
+    mongoEntity.setPriceAmount(product.price().amount());
+    mongoEntity.setItemsInStock(product.itemsInStock());
+
+    return mongoEntity;
+  }
+
+  static Product toModelEntity(ProductMongoEntity mongoEntity) {
+    return new Product(
+        new ProductId(mongoEntity.getId()),
+        mongoEntity.getName(),
+        mongoEntity.getDescription(),
+        new Money(
+            Currency.getInstance(mongoEntity.getPriceCurrency()), mongoEntity.getPriceAmount()),
+        mongoEntity.getItemsInStock());
+  }
+
+  static List<Product> toModelEntities(List<ProductMongoEntity> mongoEntities) {
+    return mongoEntities.stream().map(ProductMapper::toModelEntity).toList();
+  }
+}

--- a/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/ProductMongoEntity.java
+++ b/adapter/src/main/java/eu/happycoders/shop/adapter/out/persistence/mongo/ProductMongoEntity.java
@@ -1,0 +1,37 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.math.BigDecimal;
+
+/**
+ * MongoDB document class for a product.
+ *
+ * @author Alfredo Rueda & Francisco José Nebrera
+ */
+@Document(collection = "Product")
+@Getter
+@Setter
+public class ProductMongoEntity {
+
+  @Id private String id;
+
+  @Field("name")
+  private String name;
+
+  @Field("description")
+  private String description;
+
+  @Field("price_currency")
+  private String priceCurrency;
+
+  @Field("price_amount")
+  private BigDecimal priceAmount;
+
+  @Field("items_in_stock")
+  private int itemsInStock;
+}

--- a/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoDBCartRepositoryTest.java
+++ b/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoDBCartRepositoryTest.java
@@ -1,0 +1,19 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.adapter.out.persistence.AbstractCartRepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("test-with-mongodb")
+class MongoDBCartRepositoryTest extends AbstractCartRepositoryTest  {
+
+    @DynamicPropertySource
+    static void mongoDbProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> MongoDBTestContainerConfig.getInstance().getReplicaSetUrl());
+    }
+}

--- a/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoDBTestContainerConfig.java
+++ b/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoDBTestContainerConfig.java
@@ -1,0 +1,23 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Profile("test-with-mongodb")
+@Testcontainers
+public class MongoDBTestContainerConfig {
+
+    // See: https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers
+
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+
+    static {
+        mongoDBContainer.start();
+    }
+
+    public static MongoDBContainer getInstance() {
+        return mongoDBContainer;
+    }
+
+}

--- a/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductRepositoryTest.java
+++ b/adapter/src/test/java/eu/happycoders/shop/adapter/out/persistence/mongo/MongoProductRepositoryTest.java
@@ -1,0 +1,19 @@
+package eu.happycoders.shop.adapter.out.persistence.mongo;
+
+import eu.happycoders.shop.adapter.out.persistence.AbstractProductRepositoryTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("test-with-mongodb")
+class MongoProductRepositoryTest extends AbstractProductRepositoryTest {
+
+    @DynamicPropertySource
+    static void mongoDbProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> MongoDBTestContainerConfig.getInstance().getReplicaSetUrl());
+    }
+}

--- a/adapter/src/test/resources/application-test-with-mongodb.properties
+++ b/adapter/src/test/resources/application-test-with-mongodb.properties
@@ -1,0 +1,5 @@
+# spring.data.mongodb.uri is set to a test container via Java code
+# because is not possible to set up a test container in a properties file with MongoDB (as it is with MySQL)
+persistence=mongodb
+
+

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -53,6 +53,16 @@
             <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- To use the "attached test JAR" from the "adapter" module -->
         <dependency>

--- a/bootstrap/src/main/resources/application-mongodb.properties
+++ b/bootstrap/src/main/resources/application-mongodb.properties
@@ -1,0 +1,5 @@
+spring.data.mongodb.database=shop
+spring.data.mongodb.uri=mongodb://localhost:27017/shop
+
+persistence=mongodb
+

--- a/bootstrap/src/test/java/eu/happycoders/shop/bootstrap/e2e/CartTest.java
+++ b/bootstrap/src/test/java/eu/happycoders/shop/bootstrap/e2e/CartTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test-with-mysql")
+// Uncomment the following line to run the tests with MongoDB (and comment the previous line)
+//@ActiveProfiles("test-with-mongodb")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CartTest {
 

--- a/bootstrap/src/test/java/eu/happycoders/shop/bootstrap/e2e/FindProductsTest.java
+++ b/bootstrap/src/test/java/eu/happycoders/shop/bootstrap/e2e/FindProductsTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test-with-mysql")
+// Uncomment the following line to run the tests with MongoDB (and comment the previous line)
+//@ActiveProfiles("test-with-mongodb")
 class FindProductsTest {
 
   @LocalServerPort private Integer port;


### PR DESCRIPTION
Sven's practical approach to explaining hexagonal architecture is fantastic. Adding a persistence adapter that uses a non-relational technology is relevant, demonstrating even more explicitly that the rich domain can be fully reused.

MongoDB is a successful non-relational database system in the industry and integrates well into the Spring ecosystem. That is why it has been selected as an additional adapter in this excellent hexagonal architecture example. All tests, both unit tests and end-to-end tests, passed successfully. 

The Singleton pattern was implemented to use the same MongoDB Docker container in both tests. I would be happy to receive feedback on how to improve this implementation:
See: https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers

Of course, I am also happy to provide top-quality documentation on par with Sven's original documentation.

![image](https://github.com/user-attachments/assets/e766d56f-dc11-4f14-b3f8-d0fe193f43d0)

Co-authored-by: Francisco José Nebrera <fjnebrera@gmail.com>